### PR TITLE
Next Upcoming Berlin event in March 2018 organized by Wiredcraft

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,9 @@
           Tampere &middot; 23rd March 2018 &middot; <a href="https://www.eventbrite.com/e/code-in-the-dark-bitwise-registration-42421730538" target="_blank">RSVP</a>
         </p>
         <p>
+          Berlin &middot; 13th March 2018  &middot; <a href="https://www.meetup.com/de-DE/Berlin-Hacker-News-Meetup/events/248018512/" target="_blank">RSVP</a>
+        </p>
+        <p>
            Manila &middot; 21st February 2018 &middot; <a href="https://pwdomanilacss_citdph.eventbrite.com/" target="_blank">RSVP</a>
          </p>
         <p>


### PR DESCRIPTION
RSVP: https://www.meetup.com/de-DE/Berlin-Hacker-News-Meetup/events/248018512/