### PR TITLE
Add Montreal, Canada 2018 event

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,9 @@
     <div class="part">
       <h2>Community organized events</h2>
         <p>
+            Montreal &middot; 23rd November 2018 &middot; <a href="https://osedea.com/en/code-in-the-dark" target="_blank">RSVP</a>
+        </p>
+        <p>
             Venice &middot; 14th September 2018 &middot; <a href="https://www.interlogica.it/azienda/code-in-the-dark/" target="_blank">RSVP</a>
         </p>
         <p>


### PR DESCRIPTION
Hello,

This PR adds to the community organized events section the Montreal, Canada 2018 Code in the Dark event happening on November 23.

Link to page and tickets is found here: https://osedea.com/en/code-in-the-dark